### PR TITLE
Issue 36 clang-tidy-run-checks returns non zero on errors.

### DIFF
--- a/clang-tidy-run-checks.sh
+++ b/clang-tidy-run-checks.sh
@@ -52,6 +52,7 @@ done
 (( ${#FILES[@]} )) || exit 0
 
 CHECKS=${CHECKS:-""}
+WARNINGS_AS_ERRORS=${WARNINGS_AS_ERRORS:-"*"}
 
 ROOT=${ROOT:-"$(pwd)"}
 if command -v cygpath >/dev/null 2>&1; then
@@ -96,6 +97,9 @@ fi
 CHECKS_ARGS=()
 if [ -n "$CHECKS" ]; then
   CHECKS_ARGS+=("-checks=$CHECKS")
+fi
+if [ -n "$WARNINGS_AS_ERRORS" ]; then
+  CHECKS_ARGS+=("--warnings-as-errors=$WARNINGS_AS_ERRORS")
 fi
 
 if [ "$USE_RUN_CLANG_TIDY" = "1" ] && command -v run-clang-tidy >/dev/null 2>&1; then

--- a/tipsAndTricks/clang-tidy.md
+++ b/tipsAndTricks/clang-tidy.md
@@ -5,3 +5,9 @@ to fix all my files for 1 type of check (e.g. misc-include-cleaner)
 ```bash
 CHECKS='-*,misc-include-cleaner' bash ./clang-tidy-run-checks.sh --fix
 ```
+
+to allow warnings locally without failing the script
+
+```bash
+WARNINGS_AS_ERRORS='' bash ./clang-tidy-run-checks.sh
+```

--- a/tipsAndTricks/githubActions.md
+++ b/tipsAndTricks/githubActions.md
@@ -33,9 +33,13 @@ jobs:
 
 ## Fail on warnings
 
-If you later want stricter enforcement:
-modify your script to exit non-zero on warnings
-👉 Do this only after your warnings are stable.
+`clang-tidy-run-checks.sh` now passes `--warnings-as-errors=*` by default, so the workflow fails on any reported warning.
+
+If you need a softer local run, override it like this:
+
+```bash
+WARNINGS_AS_ERRORS='' bash ./clang-tidy-run-checks.sh
+```
 
 ## Future improvements
 


### PR DESCRIPTION
Issue #36 