### PR TITLE
Fix post-merge review issues in tidy-staged and statistics.hpp

### DIFF
--- a/include/statistics.hpp
+++ b/include/statistics.hpp
@@ -48,6 +48,7 @@
 #include <iterator>
 #include <numeric>
 #include <ranges>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/tidy-staged.sh
+++ b/tidy-staged.sh
@@ -21,10 +21,10 @@ else
 fi
 
 HEADER_FILTER_ARGS=("-header-filter=$HEADER_FILTER")
-if clang-tidy --help 2>&1 | grep -q -- '--exclude-header-filter'; then
+if "$CLANG_TIDY_BIN" --help 2>&1 | grep -q -- '--exclude-header-filter'; then
   HEADER_FILTER_ARGS+=("-exclude-header-filter=$EXCLUDE_HEADER_FILTER")
 else
-  echo "clang-tidy does not support --exclude-header-filter; continuing without it"
+  echo "$CLANG_TIDY_BIN does not support --exclude-header-filter; continuing without it"
 fi
 
 TIDY_ARGS=()


### PR DESCRIPTION
# Fix post-merge review issues in tidy-staged and statistics.hpp

Addresses the remaining review comments after issue 80:

- use `CLANG_TIDY_BIN` for `--exclude-header-filter` capability probing in `tidy-staged.sh`
- add direct `<span>` include to `statistics.hpp` so the header does not rely on transitive includes

Verification:

- `pwsh -File .\verify.ps1 quick`
- syntax-only compile check of `test/test_statistics.cpp`
