### PR TITLE
Add llvm-cov coverage workflow and local report helpers

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,48 @@
+name: coverage
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.clang
+          load: true
+          tags: cpp-ci-clang:latest
+          cache-from: type=gha,scope=dockerfile-clang
+          cache-to: type=gha,mode=max,scope=dockerfile-clang
+
+      - name: Generate coverage report
+        run: >
+          docker run --rm
+          --user $(id -u):$(id -g)
+          -v ${{ github.workspace }}:/project
+          -w /project
+          cpp-ci-clang
+          bash ./coverage-report.sh
+
+      - name: Publish coverage summary
+        run: cat out/coverage/linux-clang-coverage/summary.txt >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-linux-clang
+          path: out/coverage/linux-clang-coverage
+          if-no-files-found: error

--- a/Agents.md
+++ b/Agents.md
@@ -34,6 +34,7 @@ Typical mapping:
 
 - code changes: targeted build/test first, then broader repo checks if warranted
 - workflow changes: YAML sanity review and, when practical, the smallest local validation available
+- coverage changes: one instrumented toolchain, one clear report artifact, and a short local reproduction path
 - docs-only changes: proofread, link/path checks, and no compile/test unless the docs affect executable examples
 - CI-failure follow-ups: reproduce or patch the reported failure first before running unrelated checks
 
@@ -44,10 +45,17 @@ If full verification is blocked by environment, permissions, network limits, or 
 - Keep each pass narrow.
 - Do not stage unrelated edits.
 - Treat local task `.md` files as temporary unless the user wants them kept.
+- Delete temporary local `.md` notes once the issue they describe is resolved.
 - Prefer reusing existing helper aliases or policies over duplicating logic.
 - Prefer staying on the user's current branch unless the user asks for a new branch or the task is clearly a separate, self-contained pass.
+- If the previous branch was already merged, start follow-up fixes on a fresh branch from `main`.
 - If a new branch is created, use a descriptive name and say whether it is based on the current branch or intended to be cleanly rebased from `main`.
 - For temporary PR or scratch artifacts, create or update them only when requested and avoid committing them unless asked.
+
+## Git State
+
+- Check `git status` before assuming a conflict is from a rebase.
+- If Git says all conflicts are fixed, report the exact next command based on repo state: `git rebase --continue` for rebases, `git commit` for merges.
 
 ## Default Shortcuts
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -183,6 +183,19 @@
       }
     },
     {
+      "name": "linux-clang-coverage",
+      "generator": "Ninja",
+      "displayName": "Linux Coverage (Clang)",
+      "inherits": "linux-clang-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_C_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate"
+      }
+    },
+    {
       "name": "local-msvc-debug",
       "displayName": "Local MSVC Debug (build/Debug)",
       "generator": "Ninja",
@@ -213,6 +226,7 @@
       { "name": "linux-gcc-debug",     "configurePreset": "linux-gcc-debug" },
       { "name": "linux-gcc-release",   "configurePreset": "linux-gcc-release" },
       { "name": "linux-clang-asan",    "configurePreset": "linux-clang-asan" },
+      { "name": "linux-clang-coverage","configurePreset": "linux-clang-coverage" },
       { "name": "local-msvc-debug",    "configurePreset": "local-msvc-debug" }
   ],
   "testPresets": [
@@ -249,6 +263,11 @@
     {
       "name": "linux-clang-asan",
       "configurePreset": "linux-clang-asan",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "linux-clang-coverage",
+      "configurePreset": "linux-clang-coverage",
       "output": { "outputOnFailure": true }
     }
   ]

--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -25,6 +25,7 @@ RUN apt update && apt install -y \
     clang-22 \
     clang-format-22 \
     clang-tidy-22 \
+    llvm-22 \
     libc++-22-dev \
     libc++abi-22-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -150,6 +150,39 @@ To build and test on Windows release and debug:
 
 Git hooks are currently Bash-first on this repository. The tracked pre-commit hook calls `./format-staged.sh` and `./tidy-staged.sh`, so Windows contributors using hooks should run them from Git Bash or another Bash-capable environment.
 
+## Coverage
+
+The repository includes a small LLVM coverage path built around `llvm-profdata` and `llvm-cov`.
+
+CI coverage:
+
+- runs on one Linux Clang toolchain
+- generates a text summary, an LCOV file, and an HTML report
+- uploads the coverage directory as a GitHub Actions artifact
+
+Local reproduction:
+
+```bash
+bash ./coverage-report.sh
+```
+
+```powershell
+# Uses the local cpp-ci-clang Docker image and builds it if needed.
+pwsh -File .\coverage-report.ps1
+```
+
+The default preset is `linux-clang-coverage`, which configures Clang with `-fprofile-instr-generate -fcoverage-mapping`.
+
+To open the generated HTML report:
+
+```bash
+bash ./open-coverage-report.sh
+```
+
+```powershell
+pwsh -File .\open-coverage-report.ps1
+```
+
 ## Tooling Workflows
 
 ### WSL / Linux: LLVM 22 workflow

--- a/coverage-report.ps1
+++ b/coverage-report.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$Preset = "linux-clang-coverage"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    throw "docker is required to run coverage-report.ps1"
+}
+
+try {
+    & docker image inspect cpp-ci-clang:latest | Out-Null
+} catch {
+    & docker build -f Dockerfile.clang -t cpp-ci-clang .
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to build cpp-ci-clang image"
+    }
+}
+
+$workspace = (Resolve-Path ".").Path
+& docker run --rm `
+    -v "${workspace}:/project" `
+    -w /project `
+    cpp-ci-clang `
+    bash ./coverage-report.sh $Preset
+
+if ($LASTEXITCODE -ne 0) {
+    throw "coverage-report.sh failed"
+}

--- a/coverage-report.sh
+++ b/coverage-report.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRESET="${1:-linux-clang-coverage}"
+BUILD_DIR="out/build/${PRESET}"
+REPORT_DIR="out/coverage/${PRESET}"
+RAW_PROFILE="${REPORT_DIR}/statistics_test.profraw"
+MERGED_PROFILE="${REPORT_DIR}/statistics_test.profdata"
+LCOV_REPORT="${REPORT_DIR}/coverage.lcov"
+SUMMARY_REPORT="${REPORT_DIR}/summary.txt"
+HTML_DIR="${REPORT_DIR}/html"
+IGNORE_REGEX='(^|/)(out/build|build|_deps|third_party|external|vendor)/'
+
+find_llvm_tool() {
+  local versioned="$1"
+  local fallback="$2"
+  if command -v "$versioned" >/dev/null 2>&1; then
+    echo "$versioned"
+    return 0
+  fi
+  if command -v "$fallback" >/dev/null 2>&1; then
+    echo "$fallback"
+    return 0
+  fi
+  echo "Missing LLVM tool: tried '$versioned' and '$fallback'" >&2
+  exit 1
+}
+
+LLVM_COV_BIN="${LLVM_COV_BIN:-$(find_llvm_tool llvm-cov-22 llvm-cov)}"
+LLVM_PROFDATA_BIN="${LLVM_PROFDATA_BIN:-$(find_llvm_tool llvm-profdata-22 llvm-profdata)}"
+
+echo "Using preset: ${PRESET}"
+echo "Using llvm-cov: ${LLVM_COV_BIN}"
+echo "Using llvm-profdata: ${LLVM_PROFDATA_BIN}"
+
+cmake --preset "${PRESET}"
+cmake --build "${BUILD_DIR}"
+
+rm -rf "${REPORT_DIR}"
+mkdir -p "${HTML_DIR}"
+
+LLVM_PROFILE_FILE="${RAW_PROFILE}" "${BUILD_DIR}/statistics_test"
+
+"${LLVM_PROFDATA_BIN}" merge -sparse "${RAW_PROFILE}" -o "${MERGED_PROFILE}"
+
+"${LLVM_COV_BIN}" report "${BUILD_DIR}/statistics_test" \
+  -instr-profile="${MERGED_PROFILE}" \
+  -ignore-filename-regex="${IGNORE_REGEX}" \
+  > "${SUMMARY_REPORT}"
+
+"${LLVM_COV_BIN}" export "${BUILD_DIR}/statistics_test" \
+  -instr-profile="${MERGED_PROFILE}" \
+  -format=lcov \
+  -ignore-filename-regex="${IGNORE_REGEX}" \
+  > "${LCOV_REPORT}"
+
+"${LLVM_COV_BIN}" show "${BUILD_DIR}/statistics_test" \
+  -instr-profile="${MERGED_PROFILE}" \
+  -format=html \
+  -output-dir="${HTML_DIR}" \
+  -ignore-filename-regex="${IGNORE_REGEX}" \
+  >/dev/null
+
+echo "Coverage summary: ${SUMMARY_REPORT}"
+echo "Coverage LCOV: ${LCOV_REPORT}"
+echo "Coverage HTML: ${HTML_DIR}/index.html"

--- a/open-coverage-report.ps1
+++ b/open-coverage-report.ps1
@@ -1,0 +1,13 @@
+param(
+    [string]$Preset = "linux-clang-coverage"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$reportPath = Join-Path "out/coverage/$Preset/html" "index.html"
+if (-not (Test-Path $reportPath)) {
+    throw "Coverage report not found: $reportPath"
+}
+
+Start-Process $reportPath

--- a/open-coverage-report.sh
+++ b/open-coverage-report.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRESET="${1:-linux-clang-coverage}"
+REPORT_PATH="out/coverage/${PRESET}/html/index.html"
+
+if [[ ! -f "${REPORT_PATH}" ]]; then
+  echo "Coverage report not found: ${REPORT_PATH}" >&2
+  exit 1
+fi
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if command -v cygpath >/dev/null 2>&1; then
+      WIN_PATH="$(cygpath -w "${REPORT_PATH}")"
+      cmd.exe /c start "" "${WIN_PATH}" >/dev/null 2>&1
+      exit 0
+    fi
+    ;;
+esac
+
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "${REPORT_PATH}" >/dev/null 2>&1 &
+  exit 0
+fi
+
+if command -v open >/dev/null 2>&1; then
+  open "${REPORT_PATH}"
+  exit 0
+fi
+
+echo "No supported opener found for ${REPORT_PATH}" >&2
+exit 1


### PR DESCRIPTION
# Add llvm-cov coverage workflow and local report helpers

Implements issue #82 with a small LLVM coverage path:

- adds a `linux-clang-coverage` preset
- generates coverage with `llvm-profdata` and `llvm-cov`
- uploads coverage output as a GitHub Actions artifact
- documents a short local reproduction path
- adds simple shell and PowerShell helpers to generate and open the HTML report

Also includes a small `Agents.md` update to capture recent workflow lessons.

Verification:

- `pwsh -File .\verify.ps1 quick`
- JSON validation for `CMakePresets.json`
- PowerShell parser checks for the new coverage scripts
