### PR TITLE
Feat/issue 86 preset notes

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -45,6 +45,8 @@ If full verification is blocked by environment, permissions, network limits, or 
 - Keep each pass narrow.
 - Do not stage unrelated edits.
 - Treat local task `.md` files as temporary unless the user wants them kept.
+- Keep temporary local notes and PR scratch files untracked by default unless the user explicitly asks to commit them.
+- Prefer local scratch names such as `*-note.local.md` or `*.local.md` for temporary notes to make their status obvious.
 - Delete temporary local `.md` notes once the issue they describe is resolved.
 - Prefer reusing existing helper aliases or policies over duplicating logic.
 - Prefer staying on the user's current branch unless the user asks for a new branch or the task is clearly a separate, self-contained pass.
@@ -56,6 +58,8 @@ If full verification is blocked by environment, permissions, network limits, or 
 
 - Check `git status` before assuming a conflict is from a rebase.
 - If Git says all conflicts are fixed, report the exact next command based on repo state: `git rebase --continue` for rebases, `git commit` for merges.
+- Do not run `git add`, `git commit`, `git push`, or other history-changing Git commands in parallel.
+- Before any commit or push, verify that temporary `.md` scratch files are not staged unless the user explicitly asked to include them.
 
 ## Default Shortcuts
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(ProjectWarnings)
+include(ProjectInstrumentation)
 
 # Header-only library
 add_library(statistics INTERFACE)
@@ -102,7 +103,7 @@ enable_testing()
 # Test executable
 add_executable(statistics_test test/test_statistics.cpp)
 set_target_properties(statistics_test PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
-target_link_libraries(statistics_test PRIVATE statistics fmt::fmt gtest_main project_warnings)
+target_link_libraries(statistics_test PRIVATE statistics fmt::fmt gtest_main project_warnings project_instrumentation)
 target_include_directories(statistics_test SYSTEM PRIVATE ${FMT_INCLUDE_DIRS})
 
 include(GoogleTest)
@@ -122,6 +123,7 @@ target_link_libraries(statistics-cli
     statistics
     fmt::fmt
     project_warnings
+    project_instrumentation
 )
 target_include_directories(statistics-cli SYSTEM PRIVATE ${FMT_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,28 @@ set_target_properties(statistics_test PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
 target_link_libraries(statistics_test PRIVATE statistics fmt::fmt gtest_main project_warnings project_instrumentation)
 target_include_directories(statistics_test SYSTEM PRIVATE ${FMT_INCLUDE_DIRS})
 
+if (STATISTICS_ENABLE_ASAN)
+  # LeakSanitizer aborts in this environment when the test binary is launched
+  # through CTest/GoogleTest discovery. Run through `cmake -E env` and disable
+  # leak detection so ASan/UBSan coverage remains usable.
+  set_property(
+    TARGET statistics_test
+    PROPERTY CROSSCOMPILING_EMULATOR
+      "${CMAKE_COMMAND};-E;env;LSAN_OPTIONS=detect_leaks=0"
+  )
+endif()
+
 include(GoogleTest)
-gtest_discover_tests(statistics_test)
+set(_statistics_gtest_discovery_mode POST_BUILD)
+if (STATISTICS_ENABLE_ASAN OR STATISTICS_ENABLE_UBSAN)
+  # LeakSanitizer can abort when GoogleTest enumerates tests during the build.
+  # Discovering at CTest time avoids that build-time execution path.
+  set(_statistics_gtest_discovery_mode PRE_TEST)
+endif()
+gtest_discover_tests(
+  statistics_test
+  DISCOVERY_MODE ${_statistics_gtest_discovery_mode}
+)
 
 add_executable(statistics-cli statistics-cli/statistics-cli.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@ configure_file(
   @ONLY
 )
 
-# Use libc++ globally when compiling with Clang
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+# Use libc++ for non-Windows Clang builds. On Windows, Clang typically targets
+# the MSVC runtime/toolchain instead, and -stdlib=libc++ is rejected.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT WIN32)
   add_compile_options(-stdlib=libc++)
   add_link_options(-stdlib=libc++ -lc++ -lc++abi)
 endif()
@@ -77,6 +78,10 @@ endif()
 set(FMT_INCLUDE_DIRS $<TARGET_PROPERTY:fmt::fmt,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # Fetch GoogleTest
+if (WIN32)
+  set(gtest_disable_pthreads ON CACHE BOOL "Disable pthread usage in GoogleTest on Windows" FORCE)
+endif()
+
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,6 +19,23 @@
       }
     },
     {
+      "name": "windows-clang-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang.exe",
+        "CMAKE_CXX_COMPILER": "clang++.exe",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
       "name": "msvc-x64-debug",
       "displayName": "MSVC x64 Debug",
       "inherits": "windows-base",
@@ -35,6 +52,28 @@
       "name": "msvc-x64-release",
       "displayName": "MSVC x64 Release",
       "inherits": "msvc-x64-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "windows-clang-x64-debug",
+      "displayName": "Windows Clang x64 Debug",
+      "inherits": "windows-clang-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "windows-clang-x64-release",
+      "displayName": "Windows Clang x64 Release",
+      "inherits": "windows-clang-x64-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
@@ -211,6 +250,8 @@
   "buildPresets": [
       { "name": "msvc-x64-debug",   "configurePreset": "msvc-x64-debug" },
       { "name": "msvc-x64-release", "configurePreset": "msvc-x64-release" },
+      { "name": "windows-clang-x64-debug",   "configurePreset": "windows-clang-x64-debug" },
+      { "name": "windows-clang-x64-release", "configurePreset": "windows-clang-x64-release" },
       { "name": "linux-clang-debug",   "configurePreset": "linux-clang-debug" },
       {
         "name": "linux-clang-debug-cli",
@@ -238,6 +279,16 @@
     {
       "name": "msvc-x64-release",
       "configurePreset": "msvc-x64-release",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "windows-clang-x64-debug",
+      "configurePreset": "windows-clang-x64-debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "windows-clang-x64-release",
+      "configurePreset": "windows-clang-x64-release",
       "output": { "outputOnFailure": true }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,18 +71,15 @@
       "name": "clang-asan-base",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer",
-        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer",
-        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+        "STATISTICS_ENABLE_ASAN": "ON",
+        "STATISTICS_ENABLE_UBSAN": "ON"
       }
     },
     {
       "name": "clang-coverage-base",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate"
+        "STATISTICS_ENABLE_COVERAGE": "ON"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,68 +36,84 @@
       }
     },
     {
-      "name": "msvc-x64-debug",
-      "displayName": "MSVC x64 Debug",
-      "inherits": "windows-base",
+      "name": "windows-x64-base",
+      "hidden": true,
       "architecture": {
         "value": "x64",
         "strategy": "external"
-      },
+      }
+    },
+    {
+      "name": "windows-x86-base",
+      "hidden": true,
+      "architecture": {
+        "value": "x86",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "debug-base",
+      "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
+    },
+    {
+      "name": "release-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "clang-asan-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
+    },
+    {
+      "name": "clang-coverage-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate"
+      }
+    },
+    {
+      "name": "msvc-x64-debug",
+      "displayName": "MSVC x64 Debug",
+      "inherits": [ "windows-base", "windows-x64-base", "debug-base" ]
     },
     {
       "name": "msvc-x64-release",
       "displayName": "MSVC x64 Release",
-      "inherits": "msvc-x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "windows-base", "windows-x64-base", "release-base" ]
     },
     {
       "name": "windows-clang-x64-debug",
       "displayName": "Windows Clang x64 Debug",
-      "inherits": "windows-clang-base",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "windows-clang-base", "windows-x64-base", "debug-base" ]
     },
     {
       "name": "windows-clang-x64-release",
       "displayName": "Windows Clang x64 Release",
-      "inherits": "windows-clang-x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "windows-clang-base", "windows-x64-base", "release-base" ]
     },
     {
       "name": "msvc-x86-debug",
       "displayName": "MSVC x86 Debug",
-      "inherits": "windows-base",
-      "architecture": {
-        "value": "x86",
-        "strategy": "external"
-      },
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
+      "inherits": [ "windows-base", "windows-x86-base", "debug-base" ]
     },
     {
       "name": "msvc-x86-release",
       "displayName": "MSVC x86 Release",
-      "inherits": "msvc-x86-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "inherits": [ "windows-base", "windows-x86-base", "release-base" ]
     },
     {
       "name": "linux-base",
@@ -105,134 +121,77 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "installDir": "${sourceDir}/out/install/${presetName}",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-22",
-        "CMAKE_CXX_COMPILER": "clang++-22",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
-      }
-    },
-    {
-      "name": "linux-debug",
-      "displayName": "Linux Debug",
-      "inherits": "linux-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
-    },
-    {
-      "name": "linux-release",
-      "displayName": "Linux Release",
-      "inherits": "linux-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
     {
       "name": "linux-clang-base",
       "hidden": true,
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}",
+      "inherits": "linux-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang-22",
         "CMAKE_CXX_COMPILER": "clang++-22",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Linux"
       }
+    },
+    {
+      "name": "linux-debug",
+      "displayName": "Linux Debug",
+      "inherits": [ "linux-clang-base", "debug-base" ]
+    },
+    {
+      "name": "linux-release",
+      "displayName": "Linux Release",
+      "inherits": [ "linux-clang-base", "release-base" ]
     },
     {
       "name": "linux-gcc-base",
       "hidden": true,
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}",
+      "inherits": "linux-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Linux"
       }
     },
     {
       "name": "linux-clang-debug",
       "generator": "Ninja",
       "displayName": "Linux Debug (Clang)",
-      "inherits": "linux-clang-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "linux-clang-base", "debug-base" ]
     },
     {
       "name": "linux-clang-release",
       "generator": "Ninja",
       "displayName": "Linux Release (Clang)",
-      "inherits": "linux-clang-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "linux-clang-base", "release-base" ]
     },
     {
       "name": "linux-gcc-debug",
       "generator": "Ninja",
       "displayName": "Linux Debug (gcc)",
-      "inherits": "linux-gcc-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "linux-gcc-base", "debug-base" ]
     },
     {
       "name": "linux-gcc-release",
       "generator": "Ninja",
       "displayName": "Linux Release (gcc)",
-      "inherits": "linux-gcc-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": [ "linux-gcc-base", "release-base" ]
     },
     {
       "name": "linux-clang-asan",
       "generator": "Ninja",
       "displayName": "Linux ASan+UBSan (Clang)",
-      "inherits": "linux-clang-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer",
-        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer",
-        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
-      }
+      "inherits": [ "linux-clang-base", "debug-base", "clang-asan-base" ]
     },
     {
       "name": "linux-clang-coverage",
       "generator": "Ninja",
       "displayName": "Linux Coverage (Clang)",
-      "inherits": "linux-clang-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_C_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate"
-      }
+      "inherits": [ "linux-clang-base", "debug-base", "clang-coverage-base" ]
     },
     {
       "name": "local-msvc-debug",
@@ -240,10 +199,9 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/Debug",
       "installDir": "${sourceDir}/build/install/Debug",
+      "inherits": "debug-base",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_COMPILER": "cl.exe",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_CXX_COMPILER": "cl.exe"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ This separates the Windows workflows more cleanly:
 - `linux-clang-asan` for sanitizer runs
 - `linux-clang-coverage` for coverage reports
 
+The Clang sanitizer and coverage presets now enable project-level CMake options
+instead of injecting raw instrumentation flags directly in each public preset.
+
 > **Note:** The intended workflow is plain PowerShell on Windows. If a local
 > shell resolves unexpected compiler paths, verify `where clang`, `where cl`,
 > and the active SDK/toolchain paths before assuming the preset itself is wrong.

--- a/README.md
+++ b/README.md
@@ -319,9 +319,9 @@ This separates the Windows workflows more cleanly:
 - `linux-clang-asan` for sanitizer runs
 - `linux-clang-coverage` for coverage reports
 
-> **Note:** On Windows, both MSVC and Windows Clang presets may work best when
-> VS Code or PowerShell is launched from a Visual Studio Developer PowerShell so
-> the MSVC environment and SDK paths are already set up.
+> **Note:** The intended workflow is plain PowerShell on Windows. If a local
+> shell resolves unexpected compiler paths, verify `where clang`, `where cl`,
+> and the active SDK/toolchain paths before assuming the preset itself is wrong.
 
 ### Practical contributor split
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ ctest --preset msvc-x64-debug
 .\verify.ps1 quick
 ```
 
+For a coverage report from Windows without setting up local Linux tooling:
+
+```powershell
+pwsh -File .\coverage-report.ps1
+pwsh -File .\open-coverage-report.ps1
+```
+
 VS Code:
 
 - open the folder
@@ -295,6 +302,26 @@ cmake --preset msvc-x64-release
 cmake --build --preset msvc-x64-release
 ctest --preset msvc-x64-release
 ```
+
+If you want a Clang-native compilation database for editor tooling or
+`clang-tidy`, use the Windows Clang presets:
+
+```powershell
+cmake --preset windows-clang-x64-debug
+cmake --build --preset windows-clang-x64-debug
+ctest --preset windows-clang-x64-debug
+```
+
+This separates the Windows workflows more cleanly:
+
+- `msvc-x64-*` for native Windows build/test
+- `windows-clang-x64-*` for Clang-oriented analysis and `compile_commands.json`
+- `linux-clang-asan` for sanitizer runs
+- `linux-clang-coverage` for coverage reports
+
+> **Note:** On Windows, both MSVC and Windows Clang presets may work best when
+> VS Code or PowerShell is launched from a Visual Studio Developer PowerShell so
+> the MSVC environment and SDK paths are already set up.
 
 ### Practical contributor split
 

--- a/cmake/ProjectInstrumentation.cmake
+++ b/cmake/ProjectInstrumentation.cmake
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.16)
+
+option(STATISTICS_ENABLE_ASAN "Enable AddressSanitizer for supported builds" OFF)
+option(STATISTICS_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer for supported builds" OFF)
+option(STATISTICS_ENABLE_COVERAGE "Enable source-based coverage instrumentation for supported builds" OFF)
+
+add_library(project_instrumentation INTERFACE)
+
+set(_statistics_instrumentation_compile_flags "")
+set(_statistics_instrumentation_link_flags "")
+
+if (STATISTICS_ENABLE_COVERAGE)
+  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "STATISTICS_ENABLE_COVERAGE requires Clang in this project.")
+  endif()
+  list(APPEND _statistics_instrumentation_compile_flags
+    -fprofile-instr-generate
+    -fcoverage-mapping
+  )
+  list(APPEND _statistics_instrumentation_link_flags
+    -fprofile-instr-generate
+  )
+endif()
+
+set(_statistics_sanitizer_names "")
+if (STATISTICS_ENABLE_ASAN)
+  list(APPEND _statistics_sanitizer_names address)
+endif()
+if (STATISTICS_ENABLE_UBSAN)
+  list(APPEND _statistics_sanitizer_names undefined)
+endif()
+
+if (_statistics_sanitizer_names)
+  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    message(FATAL_ERROR "STATISTICS_ENABLE_ASAN/UBSAN require Clang or GCC in this project.")
+  endif()
+  string(JOIN "," _statistics_sanitizers ${_statistics_sanitizer_names})
+  list(APPEND _statistics_instrumentation_compile_flags
+    -fsanitize=${_statistics_sanitizers}
+    -fno-omit-frame-pointer
+  )
+  list(APPEND _statistics_instrumentation_link_flags
+    -fsanitize=${_statistics_sanitizers}
+  )
+endif()
+
+if (_statistics_instrumentation_compile_flags)
+  target_compile_options(project_instrumentation INTERFACE
+    $<$<COMPILE_LANGUAGE:CXX>:${_statistics_instrumentation_compile_flags}>
+  )
+endif()
+
+if (_statistics_instrumentation_link_flags)
+  target_link_options(project_instrumentation INTERFACE
+    ${_statistics_instrumentation_link_flags}
+  )
+endif()


### PR DESCRIPTION
# Make CMake presets more composable and split Windows Clang workflow

## Summary

This PR takes a substantial first implementation pass on issue `#86`.

It does **not** attempt the entire long-term cleanup at once, but it does make
the preset structure more composable and separates the main workflows more cleanly.

## What changed

- added dedicated Windows Clang presets:
  - `windows-clang-x64-debug`
  - `windows-clang-x64-release`
- kept `msvc-x64-*` as the native Windows build/test path
- refactored `CMakePresets.json` around hidden reusable bases for:
  - compiler family / host
  - Windows architecture
  - build type
  - instrumentation
- preserved the existing public preset names while cleaning up inheritance
- moved sanitizer and coverage behavior out of raw preset flag strings and into
  project-level CMake options:
  - `STATISTICS_ENABLE_ASAN`
  - `STATISTICS_ENABLE_UBSAN`
  - `STATISTICS_ENABLE_COVERAGE`
- added `cmake/ProjectInstrumentation.cmake` and wired it through an interface
  target
- fixed the plain-PowerShell Windows Clang path by:
  - avoiding `-stdlib=libc++` on Windows Clang
  - disabling GoogleTest pthread probing on Windows
- adjusted GoogleTest discovery for ASan/UBSan so the WSL/Linux sanitizer path
  remains usable
- updated `README.md` to reflect the workflow split and the coverage path from
  Windows

## Workflow model after this PR

- `msvc-x64-*`:
  native Windows build/test
- `windows-clang-x64-*`:
  Windows Clang analysis / `compile_commands.json`
- `linux-clang-asan`:
  sanitizer path
- `linux-clang-coverage`:
  coverage path

## Verification

Windows / local:

- `cmake --list-presets`
- `git diff --check`
- verified Windows Clang `compile_commands.json` shape
- smoke-tested:
  - `ctest --preset windows-clang-x64-debug -R "StatisticsTest\\.Summary_Basic" --output-on-failure`

WSL/Linux:

- follow-up branch work added the ASan GoogleTest discovery fix
- smoke-reviewed from Windows side after that commit

## Notes

- This is a meaningful implementation pass for `#86`, but not the final word on
  preset design.
- The branch focuses on practical composability and workflow separation without
  trying to redesign every preset consumer in one pass.
