### PR TITLE
Clarify Windows Clang usage and clean up preset aliases

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -37,8 +37,10 @@ Typical mapping:
 - coverage changes: one instrumented toolchain, one clear report artifact, and a short local reproduction path
 - docs-only changes: proofread, link/path checks, and no compile/test unless the docs affect executable examples
 - CI-failure follow-ups: reproduce or patch the reported failure first before running unrelated checks
+- preset/toolchain changes: verify the intended configure/build/test path end-to-end and check sibling debug/release variants when the issue is about preset usability rather than a single build type
 
-If full verification is blocked by environment, permissions, network limits, or missing tools, report the blocker and use the best local fallback.
+If full verification is blocked by environment, permissions, network limits, sandbox limits, or missing tools, report the blocker and use the best local fallback.
+If an important configure/build/test command hangs or fails only inside the sandbox, rerun it with escalation before treating the toolchain or preset as broken.
 
 ## Scoping Rules
 
@@ -60,6 +62,7 @@ If full verification is blocked by environment, permissions, network limits, or 
 - If Git says all conflicts are fixed, report the exact next command based on repo state: `git rebase --continue` for rebases, `git commit` for merges.
 - Do not run `git add`, `git commit`, `git push`, or other history-changing Git commands in parallel.
 - Before any commit or push, verify that temporary `.md` scratch files are not staged unless the user explicitly asked to include them.
+- Distinguish a merged PR from a merely closed PR before deciding whether to reuse a branch, replace a PR, or start from fresh `main`.
 
 ## Default Shortcuts
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -135,16 +135,6 @@
       }
     },
     {
-      "name": "linux-debug",
-      "displayName": "Linux Debug",
-      "inherits": [ "linux-clang-base", "debug-base" ]
-    },
-    {
-      "name": "linux-release",
-      "displayName": "Linux Release",
-      "inherits": [ "linux-clang-base", "release-base" ]
-    },
-    {
       "name": "linux-gcc-base",
       "hidden": true,
       "inherits": "linux-base",


### PR DESCRIPTION
## Summary
- remove redundant `linux-debug` / `linux-release` aliases in favor of the explicit `linux-clang-*` names
- surface the validated Windows Clang debug flow in the README quick start
- record a few durable agent notes from this preset/toolchain pass

## What changed
The public preset list still had `linux-debug` / `linux-release` aliases that duplicated the same Clang-backed configurations already exposed as `linux-clang-debug` / `linux-clang-release`.

This PR removes those aliases to make the public preset set clearer, updates the README quick start so the validated Windows Clang path is visible near the top of the docs, and updates `Agents.md` with a few lessons from this pass:
- treat preset/toolchain changes as end-to-end configure/build/test work
- check sibling debug/release variants when closing preset-usability issues
- rerun important verification outside the sandbox when the sandbox is the blocker
- distinguish merged PRs from merely closed PRs before deciding branch reuse

## Verification
```powershell
cmake --preset windows-clang-x64-debug
cmake --build --preset windows-clang-x64-debug
ctest --preset windows-clang-x64-debug

cmake --preset windows-clang-x64-release
cmake --build --preset windows-clang-x64-release
ctest --preset windows-clang-x64-release

cmake --list-presets
```

Verified locally:
- Windows Clang debug configure/build/test passed
- Windows Clang release configure/build/test passed
- preset listing still parses after removing the redundant Linux aliases
- no remaining repo references to `linux-debug` / `linux-release`