### PR TITLE
Clarify Windows Clang quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,16 @@ ctest --preset linux-gcc-debug
 Windows PowerShell:
 
 ```powershell
+# Native MSVC
 cmake --preset msvc-x64-debug
 cmake --build --preset msvc-x64-debug
 ctest --preset msvc-x64-debug
 .\verify.ps1 quick
+
+# Windows Clang
+cmake --preset windows-clang-x64-debug
+cmake --build --preset windows-clang-x64-debug
+ctest --preset windows-clang-x64-debug
 ```
 
 For a coverage report from Windows without setting up local Linux tooling:


### PR DESCRIPTION
## Summary
- surface the validated Windows Clang debug flow in the README quick start
- keep the existing detailed Windows section unchanged

## Verification
- README quick-start section reviewed for consistency with the existing Windows Clang commands later in the file