### PR TITLE
Add release workflow docs and version helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+- Tooling: add a lightweight release workflow document and a helper script for safe version bumps.
 - Documentation: clarify quartile convention used by the library.
   - The library uses the Tukey hinge quartile method and, by default, uses the
     exclusive-median variant (median excluded from lower/upper halves when computing

--- a/Doxyfile
+++ b/Doxyfile
@@ -6,7 +6,7 @@ ALLOW_UNICODE_NAMES    = YES
 OUTPUT_LANGUAGE        = English
 USE_MDFILE_AS_MAINPAGE = README.md
 
-INPUT                  = include README.md docs/llvm-setup.md
+INPUT                  = include README.md docs/llvm-setup.md docs/release-process.md
 FILE_PATTERNS          = *.hpp *.md
 RECURSIVE              = NO
 EXCLUDE_PATTERNS       =

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Internal calculation may widen independently from the public result type. For ex
 
 ## Tooling and Platform Setup
 
-For the full LLVM setup, verification, and version-update workflow, see
-[docs/llvm-setup.md](docs/llvm-setup.md).
+For the full LLVM setup workflow, see [docs/llvm-setup.md](docs/llvm-setup.md).
+For release/versioning workflow, including the Python 3 version-bump helper, see [docs/release-process.md](docs/release-process.md).
 
 Short version:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,140 @@
+# Release Process
+
+This repository uses a small manual release flow. Release intent stays human-controlled, while version editing is automated enough to avoid typo-prone ad hoc changes.
+
+## Versioning
+
+The project follows a lightweight SemVer-style policy:
+
+- major: breaking API or behavior change
+- minor: backward-compatible feature
+- patch: bug fix, docs-only maintenance release, or small tooling cleanup
+
+Current source of truth:
+
+- [`CMakeLists.txt`](../CMakeLists.txt) `project(... VERSION ...)`
+
+The generated version header is derived from that CMake version during configure and should not be edited directly.
+
+## Release Payload
+
+Initial releases should stay small and maintainable.
+
+Expected release payload:
+
+- Git tag
+- GitHub Release
+- release notes
+- updated `CHANGELOG.md`
+- generated Doxygen HTML artifact
+
+Coverage is treated as a CI/review artifact, not a formal release artifact.
+
+Current repo support:
+
+- `.github/workflows/doxygen.yml` already uploads a `doxygen-html` artifact and publishes docs from `main`
+- `.github/workflows/coverage.yml` already uploads a coverage artifact and summary
+- `.github/workflows/clang.yml` and `.github/workflows/msvc.yml` already archive release-oriented CLI package artifacts on `main` or `workflow_dispatch`
+
+Optional later:
+
+- packaged CLI binaries for selected platforms
+
+## Pre-release Checklist
+
+Use the smallest checklist that still gives confidence in the release.
+
+Recommended checklist:
+
+1. Run a quick formatting/verification pass.
+2. Build and test on at least one main supported path.
+3. Generate a coverage report and inspect obvious blind spots.
+4. Generate documentation.
+5. Run one manual CLI smoke test.
+6. Update the version and changelog.
+7. Tag the release and publish GitHub release notes.
+
+Suggested commands:
+
+```powershell
+# Quick verification
+pwsh -File .\verify.ps1 quick
+
+# Main Windows path
+cmake --preset msvc-x64-release
+cmake --build --preset msvc-x64-release
+ctest --preset msvc-x64-release
+
+# Coverage
+pwsh -File .\coverage-report.ps1
+
+# Optional docs verification/build
+bash ./doxygen-docs.sh --verify
+bash ./doxygen-docs.sh
+
+# CLI smoke test
+.\out\build\msvc-x64-release\statistics.exe summary --data 1,2,2,3,5
+```
+
+Linux / WSL maintainers can substitute the equivalent documented Linux or Docker paths where appropriate.
+
+## Version Bump Flow
+
+Choose the release type manually, then use the helper to apply the actual version change.
+
+Requirements:
+
+- Python 3.9 or newer
+- a working `python` command in your current shell, or the Windows `py -3` launcher
+
+Examples:
+
+```powershell
+python .\tools\version_bump.py patch
+python .\tools\version_bump.py minor
+python .\tools\version_bump.py 1.2.3
+python .\tools\version_bump.py --dry-run patch
+```
+
+Expected flow:
+
+1. Decide whether the release is major, minor, or patch.
+2. Run the version bump helper.
+3. Add a changelog entry under the released version.
+4. Re-run the relevant verification path.
+5. Commit the version/changelog changes.
+6. Tag the release, for example `v1.2.3`.
+7. Create the GitHub Release and attach release notes.
+
+The helper updates only `CMakeLists.txt`. Changelog content stays manual on purpose.
+
+## Changelog and Tagging
+
+Before tagging:
+
+- move relevant entries from `## [Unreleased]` into a versioned section
+- confirm the release notes match the actual merged work
+- make sure the tag matches the bumped CMake version
+
+Suggested tag shape:
+
+- `vMAJOR.MINOR.PATCH`
+
+## Coverage and Additional Tests
+
+Coverage is a signal, not a target to game.
+
+Add more tests when coverage highlights meaningful blind spots such as:
+
+- edge cases in newer statistics APIs
+- degenerate or empty-input handling
+- surprising result-type behavior
+- release-critical CLI behavior
+
+Do not add tests only to inflate a percentage with low-value assertions.
+
+## Notes
+
+- Keep the release process lightweight and repeatable.
+- Avoid full release automation until the repository genuinely needs it.
+- Prefer documenting the current reliable workflow over inventing parallel tooling.

--- a/tools/version_bump.py
+++ b/tools/version_bump.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CMAKE_LISTS = PROJECT_ROOT / "CMakeLists.txt"
+VERSION_PATTERN = re.compile(r"(^\s*VERSION\s+)(\d+)\.(\d+)\.(\d+)(\s*$)", re.MULTILINE)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bump the project version in CMakeLists.txt."
+    )
+    parser.add_argument(
+        "target",
+        help="One of: major, minor, patch, or an explicit version like 1.2.3",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the version change without rewriting CMakeLists.txt.",
+    )
+    return parser.parse_args()
+
+
+def read_current_version(text: str) -> tuple[str, tuple[int, int, int], re.Match[str]]:
+    match = VERSION_PATTERN.search(text)
+    if match is None:
+        raise ValueError("Could not find a project VERSION entry in CMakeLists.txt")
+
+    version_text = ".".join(match.group(index) for index in range(2, 5))
+    version = tuple(int(match.group(index)) for index in range(2, 5))
+    return version_text, version, match
+
+
+def resolve_target(target: str, current: tuple[int, int, int]) -> tuple[int, int, int]:
+    if target == "major":
+        return current[0] + 1, 0, 0
+    if target == "minor":
+        return current[0], current[1] + 1, 0
+    if target == "patch":
+        return current[0], current[1], current[2] + 1
+
+    explicit = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", target)
+    if explicit is None:
+        raise ValueError("Target must be major, minor, patch, or an explicit X.Y.Z version")
+
+    return tuple(int(explicit.group(index)) for index in range(1, 4))
+
+
+def detect_encoding(raw: bytes) -> str:
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return "utf-8-sig"
+    return "utf-8"
+
+
+def main() -> int:
+    args = parse_args()
+    raw = CMAKE_LISTS.read_bytes()
+    encoding = detect_encoding(raw)
+    text = raw.decode(encoding)
+    current_text, current_version, match = read_current_version(text)
+    next_version = resolve_target(args.target, current_version)
+    next_text = ".".join(str(part) for part in next_version)
+
+    if next_text == current_text:
+        print(f"Version unchanged: {current_text}")
+        return 0
+
+    print(f"Bumped version: {current_text} -> {next_text}")
+    if args.dry_run:
+        return 0
+
+    updated = (
+        text[: match.start()]
+        + f"{match.group(1)}{next_text}{match.group(5)}"
+        + text[match.end() :]
+    )
+    CMAKE_LISTS.write_bytes(updated.encode(encoding))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
Fixes #95.

## Summary
- add a lightweight release-process document aligned with the repo's current verification, coverage, docs, and tagging workflows
- add a small helper script that safely bumps the CMake project version for `major`, `minor`, `patch`, or an explicit `X.Y.Z`
- add a minimal README pointer to the new release-process doc
- record the release-workflow/tooling addition in `CHANGELOG.md` under `Unreleased`

## Scope
- keep release intent manual
- keep `CMakeLists.txt` as the version source of truth
- treat coverage as a signal and CI artifact rather than a formal release artifact
- avoid adding a full release automation system

## Verification
- `python .\tools\version_bump.py --dry-run patch`
- `python .\tools\version_bump.py patch`
- `python .\tools\version_bump.py 0.0.1`
- `python .\tools\version_bump.py banana`
- proofread `docs/release-process.md` against current repo scripts and workflows