### PR TITLE
Tighten template-facing docs and artifact naming

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -69,16 +69,16 @@ jobs:
           -v ${{ github.workspace }}:/project
           -w /project
           cpp-ci-clang
-          bash -lc "rm -rf out/artifacts/statistics-cli-linux-clang-${{ matrix.config }} &&
-                    mkdir -p out/artifacts/statistics-cli-linux-clang-${{ matrix.config }} &&
-                    cp -R out/package/linux-clang-${{ matrix.config }}/. out/artifacts/statistics-cli-linux-clang-${{ matrix.config }}/ &&
-                    cp README.md LICENSE out/artifacts/statistics-cli-linux-clang-${{ matrix.config }}/ &&
-                    tar -czf out/artifacts/statistics-cli-linux-clang-${{ matrix.config }}.tar.gz -C out/artifacts statistics-cli-linux-clang-${{ matrix.config }}"
+          bash -lc "rm -rf out/artifacts/cli-package-linux-clang-${{ matrix.config }} &&
+                    mkdir -p out/artifacts/cli-package-linux-clang-${{ matrix.config }} &&
+                    cp -R out/package/linux-clang-${{ matrix.config }}/. out/artifacts/cli-package-linux-clang-${{ matrix.config }}/ &&
+                    cp README.md LICENSE out/artifacts/cli-package-linux-clang-${{ matrix.config }}/ &&
+                    tar -czf out/artifacts/cli-package-linux-clang-${{ matrix.config }}.tar.gz -C out/artifacts cli-package-linux-clang-${{ matrix.config }}"
 
       - name: Upload CLI artifact (${{ matrix.config }})
         if: matrix.config == 'release' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
-          name: statistics-cli-linux-clang-${{ matrix.config }}
-          path: out/artifacts/statistics-cli-linux-clang-${{ matrix.config }}.tar.gz
+          name: cli-package-linux-clang-${{ matrix.config }}
+          path: out/artifacts/cli-package-linux-clang-${{ matrix.config }}.tar.gz
           if-no-files-found: error

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -61,7 +61,7 @@ jobs:
         if: matrix.config == 'Release' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
         shell: pwsh
         run: |
-          $stageDir = "out/artifacts/statistics-cli-${{ matrix.preset }}"
+          $stageDir = "out/artifacts/cli-package-${{ matrix.preset }}"
           $zipPath = "$stageDir.zip"
           Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
@@ -75,6 +75,6 @@ jobs:
         if: matrix.config == 'Release' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
-          name: statistics-cli-${{ matrix.preset }}
-          path: out/artifacts/statistics-cli-${{ matrix.preset }}.zip
+          name: cli-package-${{ matrix.preset }}
+          path: out/artifacts/cli-package-${{ matrix.preset }}.zip
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ If your goal is to reuse this repository as the base for a new project, start wi
 Most command examples below are intentionally written for this statistics project.
 Treat the executable names, subcommands, and sample outputs as replace-first content
 when adapting the repo into a different domain.
+The badge URLs and GitHub links near the top also still point at this repository
+and should be updated early in a derived project.
 
 Right now the project focuses on:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ If you prefer an editor-driven workflow, the CMake presets also work well from V
 If your goal is to reuse this repository as the base for a new project, start with
 [docs/template-guide.md](docs/template-guide.md).
 
+Most command examples below are intentionally written for this statistics project.
+Treat the executable names, subcommands, and sample outputs as replace-first content
+when adapting the repo into a different domain.
+
 Right now the project focuses on:
 
 - descriptive statistics such as mean, median, quartiles, variance, standard deviation, range, MAD, z-scores, covariance, correlation, and modes

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -78,6 +78,9 @@ bash ./doxygen-docs.sh
 
 Linux / WSL maintainers can substitute the equivalent documented Linux or Docker paths where appropriate.
 
+If you adapt this repository into a different project, rewrite the CLI smoke-test
+command to match the renamed executable and its real user-facing command surface.
+
 ## Version Bump Flow
 
 Choose the release type manually, then use the helper to apply the actual version change.

--- a/docs/template-guide.md
+++ b/docs/template-guide.md
@@ -95,6 +95,7 @@ These are valid to keep briefly during local bootstrap, but should be reviewed b
 - release-process examples that mention the current CLI binary name
 - changelog wording that still describes this as the statistics project
 - documentation examples that show statistics-specific commands or outputs
+- README example sections that still demonstrate the `statistics` executable and `summary` command
 
 ### Remove If Unneeded
 
@@ -175,11 +176,12 @@ Keep only if they match the new project’s maintenance style:
 1. Rename the project and README.
 2. Decide whether the CLI stays.
 3. Decide whether the namespace stays.
-4. Get one build/test path green.
-5. Rename package/export/install-facing names.
-6. Remove optional tooling you do not want.
-7. Re-run the main verification path.
-8. Only then broaden into deeper cleanup.
+4. Rewrite the most visible repo-specific examples and smoke-test commands.
+5. Get one build/test path green.
+6. Rename package/export/install-facing names.
+7. Remove optional tooling you do not want.
+8. Re-run the main verification path.
+9. Only then broaden into deeper cleanup.
 
 ## Verification Checklist
 

--- a/docs/template-guide.md
+++ b/docs/template-guide.md
@@ -91,7 +91,7 @@ These are the highest-priority project-specific names:
 These are valid to keep briefly during local bootstrap, but should be reviewed before you call the derived repo “ready”:
 
 - namespace `mally::statlib`
-- workflow artifact names that still say `statistics`
+- workflow artifact names or package labels that still use the current project name
 - release-process examples that mention the current CLI binary name
 - changelog wording that still describes this as the statistics project
 - documentation examples that show statistics-specific commands or outputs


### PR DESCRIPTION
Fixes #98.

## Summary

This follow-up tightens a few remaining template-facing rough edges after the first-pass template guide rollout.

## Changes

- generalize release artifact names in CI from `statistics-cli-*` to `cli-package-*`
- clarify that README and release-process command examples are intentionally project-specific
- call out that the top README badge URLs and GitHub links still point at this repository
- strengthen the template guide's checklist for examples, package labels, and derived-project cleanup

## Verification

- reviewed the touched workflow paths for internal artifact-name consistency
- checked the targeted docs diffs for README/template-guide/release-process alignment
